### PR TITLE
feat: add Google Analytics with opt-in consent banner

### DIFF
--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,0 +1,129 @@
+---
+// Google Analytics 4 with an opt-in / opt-out consent banner.
+//
+// Flow on first visit:
+//   - banner shows with Accept / Decline
+//   - Accept  → localStorage `analytics-consent` = "granted", load gtag.js
+//   - Decline → localStorage `analytics-consent` = "denied", do nothing
+// Subsequent visits respect the stored choice; the banner does not re-appear.
+//
+// A "Privacy preferences" link in the footer (any element with attribute
+// `data-analytics-preferences`) clears the stored choice and re-shows the
+// banner.
+//
+// No tracking script is loaded before consent is granted, and we pass
+// `anonymize_ip: true` to GA when we do load it.
+const GA_ID = "G-7E12DS9X49";
+---
+<div
+  data-analytics-banner
+  hidden
+  role="dialog"
+  aria-labelledby="analytics-title"
+  aria-describedby="analytics-desc"
+  class="fixed bottom-4 left-4 right-4 sm:left-auto sm:right-4 sm:max-w-md z-50 rounded-lg border border-(--color-border) bg-(--color-canvas) shadow-lg p-4 text-sm"
+>
+  <p id="analytics-title" class="text-(--color-ink) font-medium">
+    Help us count visits
+  </p>
+  <p id="analytics-desc" class="mt-1 text-(--color-ink-muted) leading-snug text-xs">
+    We use Google Analytics to measure page views and improve the site. No advertising, no cross-site tracking. You can change this any time from the footer.
+  </p>
+  <div class="mt-3 flex items-center gap-2">
+    <button
+      data-analytics-accept
+      type="button"
+      class="rounded-md border border-(--color-accent) bg-(--color-accent) text-white px-3 py-1.5 text-xs font-medium hover:opacity-90 transition-opacity"
+    >
+      Accept
+    </button>
+    <button
+      data-analytics-decline
+      type="button"
+      class="rounded-md border border-(--color-border) text-(--color-ink-muted) hover:text-(--color-ink) hover:border-(--color-border-strong) px-3 py-1.5 text-xs transition-colors"
+    >
+      Decline
+    </button>
+  </div>
+</div>
+
+<script is:inline define:vars={{ GA_ID }}>
+  (function () {
+    var KEY = "analytics-consent";
+    var loaded = false;
+
+    function loadGA() {
+      if (loaded) return;
+      loaded = true;
+      window.dataLayer = window.dataLayer || [];
+      window.gtag = function () { window.dataLayer.push(arguments); };
+      window.gtag("js", new Date());
+      window.gtag("config", GA_ID, { anonymize_ip: true });
+      var s = document.createElement("script");
+      s.async = true;
+      s.src = "https://www.googletagmanager.com/gtag/js?id=" + GA_ID;
+      document.head.appendChild(s);
+    }
+
+    function readChoice() {
+      try { return localStorage.getItem(KEY); } catch (_) { return null; }
+    }
+    function writeChoice(v) {
+      try { localStorage.setItem(KEY, v); } catch (_) {}
+    }
+    function clearChoice() {
+      try { localStorage.removeItem(KEY); } catch (_) {}
+    }
+
+    function showBanner() {
+      var b = document.querySelector("[data-analytics-banner]");
+      if (b) b.removeAttribute("hidden");
+    }
+    function hideBanner() {
+      var b = document.querySelector("[data-analytics-banner]");
+      if (b) b.setAttribute("hidden", "");
+    }
+
+    // Public API (exposed for the footer "Privacy preferences" link).
+    window.analyticsConsent = {
+      accept: function () { writeChoice("granted"); loadGA(); hideBanner(); },
+      decline: function () { writeChoice("denied"); hideBanner(); },
+      reset: function () { clearChoice(); showBanner(); },
+      status: function () { return readChoice(); },
+    };
+
+    function wireBannerButtons() {
+      var acc = document.querySelector("[data-analytics-accept]");
+      var dec = document.querySelector("[data-analytics-decline]");
+      if (acc) acc.addEventListener("click", window.analyticsConsent.accept);
+      if (dec) dec.addEventListener("click", window.analyticsConsent.decline);
+    }
+    function wirePrefsTriggers() {
+      // The footer "Privacy preferences" button (and anything else with
+      // data-analytics-preferences) re-opens the banner so the user can
+      // change their mind. Must work AFTER a choice has been made.
+      document.querySelectorAll("[data-analytics-preferences]").forEach(function (el) {
+        el.addEventListener("click", function (e) {
+          e.preventDefault();
+          window.analyticsConsent.reset();
+          wireBannerButtons();
+        });
+      });
+    }
+
+    function init() {
+      wirePrefsTriggers();
+      var choice = readChoice();
+      if (choice === "granted") { loadGA(); return; }
+      if (choice === "denied") { return; }
+      showBanner();
+      wireBannerButtons();
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -119,12 +119,21 @@ const affiliations = [
       <span class="font-mono text-[10px] opacity-70" title={`Built ${builtAt}`}>
         build {commit} · {builtAt}
       </span>
-      <a
-        href={withBase("/about")}
-        class="hover:text-(--color-accent) transition-colors underline-offset-3 hover:underline"
-      >
-        About this website
-      </a>
+      <div class="flex items-center gap-4">
+        <button
+          type="button"
+          data-analytics-preferences
+          class="hover:text-(--color-accent) transition-colors underline-offset-3 hover:underline cursor-pointer"
+        >
+          Privacy preferences
+        </button>
+        <a
+          href={withBase("/about")}
+          class="hover:text-(--color-accent) transition-colors underline-offset-3 hover:underline"
+        >
+          About this website
+        </a>
+      </div>
     </div>
   </Container>
 </footer>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import "~/styles/global.css";
 import Header from "~/components/Header.astro";
 import Footer from "~/components/Footer.astro";
+import Analytics from "~/components/Analytics.astro";
 import { withBase } from "~/lib/url";
 
 interface Props {
@@ -72,5 +73,6 @@ const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toString(
       <slot />
     </main>
     <Footer />
+    <Analytics />
   </body>
 </html>


### PR DESCRIPTION
## Summary

Privacy-first Google Analytics 4 (`G-7E12DS9X49`).

### Flow
- **First visit**: a small banner appears in the bottom-right corner with **Accept** / **Decline** buttons. `gtag.js` is **not** loaded until the user clicks Accept.
- **Accept**: stores `analytics-consent=granted` in localStorage, injects `gtag.js`, and initializes GA with `anonymize_ip: true`.
- **Decline**: stores `analytics-consent=denied`, hides the banner forever; no network requests to googletagmanager.com.
- **Returning visits**: the stored choice is respected silently; no banner.
- **Privacy preferences** link in the footer clears the choice and re-shows the banner so users can change their mind.

### Files
- `src/components/Analytics.astro` (new) — banner markup + inline consent script. Exposes `window.analyticsConsent.{accept,decline,reset,status}` for testability.
- `src/layouts/BaseLayout.astro` — includes `<Analytics />` before `</body>` so it ships on every page.
- `src/components/Footer.astro` — new "Privacy preferences" button next to "About this website".

### Test plan
- [x] `npm run build` — 199 pages built; banner markup + consent script present in every HTML file.
- [x] No pre-rendered `<script src="…googletagmanager…">` in `dist/` (only the URL string inside the consent JS, used after Accept).
- [ ] CI green.

https://claude.ai/code/session_01AvCkmLfaM2wk5rxXDc6XRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvCkmLfaM2wk5rxXDc6XRg)_