### PR TITLE
data(publications): fix author name Pierre Bellec → Lune Bellec

### DIFF
--- a/src/data/publications.yml
+++ b/src/data/publications.yml
@@ -6066,7 +6066,7 @@
   - Yibei Chen
   - M Ghavami
   - Marie St-Laurent
-  - Pierre Bellec
+  - Lune Bellec
   - Satrajit S Ghosh
   venue: bioRxiv
   doi: 10.64898/2026.05.31.729141


### PR DESCRIPTION
## Summary

Fixes an author name on the Chen et al. 2026 brain-states preprint (`10.64898/2026.05.31.729141`).

The source metadata listed the author only as the initial **"Bellec L"**, which I wrongly expanded to *Pierre Bellec* when adding the entry in #157. The correct given name is **Lune** — Lune Bellec (CNeuroMod). Corrected `Pierre Bellec` → `Lune Bellec`.

## Test plan
- [x] `npm run build` — 205 pages, clean
- [ ] CI green

https://claude.ai/code/session_01AvCkmLfaM2wk5rxXDc6XRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvCkmLfaM2wk5rxXDc6XRg)_