### PR TITLE
feat(schema): LinkML schema for site data + CI validation (PROV-DM + SKOS)

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,0 +1,35 @@
+name: Validate data
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/data/**"
+      - "schema/**"
+      - ".github/workflows/validate-data.yml"
+  pull_request:
+    paths:
+      - "src/data/**"
+      - "schema/**"
+      - ".github/workflows/validate-data.yml"
+
+jobs:
+  linkml-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install LinkML
+        run: pip install linkml pyyaml
+
+      - name: Compile schema (fails on schema errors)
+        run: gen-json-schema schema/sensein.yaml > /dev/null
+
+      - name: Validate site data against schema
+        run: python schema/validate_data.py

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,48 @@
+# Data schema
+
+[`sensein.yaml`](./sensein.yaml) is a [LinkML](https://linkml.io) schema for the
+structured YAML that drives the site (everything in [`../src/data/`](../src/data)).
+It exists so the data can be validated in CI and so the model is documented and
+ontology-aligned.
+
+## What it covers
+
+| Data file | Target class |
+|---|---|
+| `team_members.yml`, `students.yml`, `alumni_members.yml` | `TeamMember` |
+| `collaborators.yml` | `Collaborator` |
+| `projects.yml` | `Project` (+ `ProjectLink`, `ProjectContributors`) |
+| `publications.yml` | `Publication` (+ `PreprintRef`) |
+| `publist.yml` | `FeaturedPublication` (+ `LinkDisplay`) |
+| `news.yml` | `NewsItem` |
+| `publications_page.yml` | `PublicationsPage` (+ `TopicArea`) |
+
+## Design
+
+- **PROV-DM typing.** Classes mix in one of three abstract PROV mixins so the
+  data is provenance-typed: people (`TeamMember`, `Collaborator`) are
+  `prov:Agent`, projects (`Project`) are `prov:Activity`, and everything else
+  (publications, links, news, page content) is `prov:Entity`. Relational slots
+  carry PROV predicates via `slot_uri` — e.g. `authors` → `prov:wasAttributedTo`,
+  `preprints` → `prov:wasRevisionOf`, `sources` → `prov:wasDerivedFrom`,
+  `publications`/`projects` → `prov:generated`/`prov:wasGeneratedBy`,
+  `contributors` → `prov:qualifiedAssociation`.
+- **SKOS ontology alignment.** Every class and slot is aligned to external
+  vocabularies (schema.org, Dublin Core Terms, FOAF, FaBiO/SPAR, BIBO, PRISM,
+  Wikidata) through SKOS mapping predicates — `exact_mappings`,
+  `close_mappings`, and `related_mappings`.
+- **Enum meanings.** Every permissible value in every enum (`ProjectStatus`,
+  `PublicationType`, `PublicationCategory`, `AbstractSource`) carries a
+  `meaning:` binding to an ontology term (e.g. `journal` → `fabio:JournalArticle`,
+  `pubmed` → `wikidata:Q180686`).
+
+## Validate locally
+
+```bash
+pip install linkml pyyaml
+python schema/validate_data.py
+```
+
+The script validates every record in each data file against its target class
+and exits non-zero on any error. CI runs the same check on changes to
+`src/data/**` or `schema/**` (see `.github/workflows/validate-data.yml`).

--- a/schema/sensein.yaml
+++ b/schema/sensein.yaml
@@ -1,0 +1,964 @@
+id: https://w3id.org/sensein/website-schema
+name: sensein-website
+title: Senseable Intelligence Group Website Data Schema
+description: >-
+  LinkML schema for the structured YAML data that drives the Senseable
+  Intelligence Group website (people, collaborators, research projects,
+  publications, news, and page content). Classes are aligned to external
+  vocabularies via SKOS mapping predicates and typed against the W3C PROV-DM
+  as agents, activities, and entities. Used to validate the data files in
+  src/data/ in CI.
+license: https://creativecommons.org/licenses/by/4.0/
+default_range: string
+default_prefix: sensein
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  sensein: https://w3id.org/sensein/website-schema/
+  skos: http://www.w3.org/2004/02/skos/core#
+  dcterms: http://purl.org/dc/terms/
+  foaf: http://xmlns.com/foaf/0.1/
+  schema: http://schema.org/
+  prov: http://www.w3.org/ns/prov#
+  fabio: http://purl.org/spar/fabio/
+  bibo: http://purl.org/ontology/bibo/
+  prism: http://prismstandard.org/namespaces/basic/2.0/
+  org: http://www.w3.org/ns/org#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  wikidata: http://www.wikidata.org/entity/
+  xsd: http://www.w3.org/2001/XMLSchema#
+
+imports:
+  - linkml:types
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Classes
+# ─────────────────────────────────────────────────────────────────────────────
+classes:
+
+  # ---- PROV-DM mixins ----------------------------------------------------------
+  ProvenanceAgent:
+    abstract: true
+    mixin: true
+    description: >-
+      PROV-DM Agent mixin. A thing that bears responsibility for an activity or
+      the existence of an entity (here: people).
+    class_uri: prov:Agent
+    exact_mappings:
+      - prov:Agent
+
+  ProvenanceActivity:
+    abstract: true
+    mixin: true
+    description: >-
+      PROV-DM Activity mixin. Something that occurs over a period and acts upon
+      or with entities (here: research projects).
+    class_uri: prov:Activity
+    exact_mappings:
+      - prov:Activity
+
+  ProvenanceEntity:
+    abstract: true
+    mixin: true
+    description: >-
+      PROV-DM Entity mixin. A physical, digital, or conceptual thing (here:
+      publications, links, news items, page content).
+    class_uri: prov:Entity
+    exact_mappings:
+      - prov:Entity
+
+  # ---- People ------------------------------------------------------------------
+  TeamMember:
+    description: A current or former member (or student) of the group.
+    mixins:
+      - ProvenanceAgent
+    class_uri: foaf:Person
+    exact_mappings:
+      - foaf:Person
+      - schema:Person
+    close_mappings:
+      - prov:Person
+    slots:
+      - name
+      - photo
+      - info
+      - email
+      - github
+      - linkedin
+      - website
+      - scholar
+      - orcid
+      - twitter
+      - bluesky
+      - duration
+      - number_educ
+      - education1
+      - education2
+      - education3
+      - education4
+      - education5
+    slot_usage:
+      name:
+        required: true
+
+  Collaborator:
+    description: >-
+      A person the group has collaborated with, with their current institution
+      and the projects/efforts they contributed to.
+    mixins:
+      - ProvenanceAgent
+    class_uri: foaf:Person
+    exact_mappings:
+      - foaf:Person
+      - schema:Person
+    slots:
+      - name
+      - current_institution
+      - projects
+      - years
+      - note
+    slot_usage:
+      name:
+        required: true
+
+  # ---- Projects ----------------------------------------------------------------
+  Project:
+    description: A research project or programme the group runs or contributes to.
+    mixins:
+      - ProvenanceActivity
+    class_uri: schema:ResearchProject
+    exact_mappings:
+      - schema:ResearchProject
+    close_mappings:
+      - foaf:Project
+      - prov:Activity
+    slots:
+      - slug
+      - title
+      - status
+      - description
+      - funder
+      - image
+      - themes
+      - links
+      - contributors
+      - publications
+    slot_usage:
+      slug:
+        required: true
+        identifier: true
+      title:
+        required: true
+      status:
+        required: true
+
+  ProjectLink:
+    description: A labelled outbound hyperlink attached to a project.
+    mixins:
+      - ProvenanceEntity
+    class_uri: schema:WebPage
+    exact_mappings:
+      - schema:WebPage
+    related_mappings:
+      - rdfs:seeAlso
+    slots:
+      - label
+      - url
+
+  ProjectContributors:
+    description: >-
+      Grouping of the people associated with a project, split into current and
+      former lab members (resolved to roster links) and external collaborators.
+    class_uri: prov:Association
+    close_mappings:
+      - prov:Association
+      - schema:contributor
+    slots:
+      - current
+      - former
+      - external
+
+  # ---- Publications ------------------------------------------------------------
+  Publication:
+    description: >-
+      A publication or preprint in the curated corpus (the canonical record of
+      record; superseded preprints are attached via `preprints`).
+    mixins:
+      - ProvenanceEntity
+    class_uri: fabio:Expression
+    exact_mappings:
+      - schema:ScholarlyArticle
+    close_mappings:
+      - bibo:AcademicArticle
+      - fabio:Expression
+    slots:
+      - id
+      - type
+      - category
+      - year
+      - title
+      - authors
+      - venue
+      - doi
+      - pmid
+      - pmcid
+      - arxiv
+      - url
+      - pdf_url
+      - github
+      - sources
+      - projects
+      - lab_authors
+      - topics
+      - preprints
+      - cited_by
+      - abstract
+      - abstract_source
+      - key_findings
+    slot_usage:
+      id:
+        required: true
+        identifier: true
+      type:
+        required: true
+      category:
+        required: true
+      year:
+        required: true
+      title:
+        required: true
+      authors:
+        required: true
+      topics:
+        required: true
+
+  PreprintRef:
+    description: >-
+      A preprint precursor superseded by a published-of-record publication.
+    mixins:
+      - ProvenanceEntity
+    class_uri: fabio:Preprint
+    exact_mappings:
+      - fabio:Preprint
+    close_mappings:
+      - schema:ScholarlyArticle
+    slots:
+      - id
+      - venue
+      - url
+      - year
+      - doi
+      - arxiv
+    slot_usage:
+      id:
+        required: true
+
+  FeaturedPublication:
+    description: >-
+      A manually-curated highlight entry (legacy publist.yml) shown on the
+      home/publications pages.
+    mixins:
+      - ProvenanceEntity
+    class_uri: schema:ScholarlyArticle
+    exact_mappings:
+      - schema:ScholarlyArticle
+    close_mappings:
+      - bibo:AcademicArticle
+    slots:
+      - title
+      - image
+      - description
+      - authors
+      - type
+      - date
+      - link
+      - code link
+      - highlight
+      - news1
+      - news2
+    slot_usage:
+      title:
+        required: true
+      authors:
+        multivalued: false
+        range: string
+      type:
+        range: string
+
+  LinkDisplay:
+    description: A hyperlink with a display label (used by featured publications).
+    mixins:
+      - ProvenanceEntity
+    class_uri: schema:WebPage
+    exact_mappings:
+      - schema:WebPage
+    slots:
+      - url
+      - display
+
+  # ---- News --------------------------------------------------------------------
+  NewsItem:
+    description: A dated one-line news/announcement entry.
+    mixins:
+      - ProvenanceEntity
+    class_uri: schema:NewsArticle
+    exact_mappings:
+      - schema:NewsArticle
+    close_mappings:
+      - bibo:Note
+    slots:
+      - date
+      - headline
+    slot_usage:
+      date:
+        required: true
+      headline:
+        required: true
+
+  # ---- Publications page content ----------------------------------------------
+  PublicationsPage:
+    description: >-
+      Page content for /publications/ — summary text, a keyword cloud, and the
+      topic-area cards.
+    mixins:
+      - ProvenanceEntity
+    class_uri: schema:CollectionPage
+    exact_mappings:
+      - schema:CollectionPage
+    slots:
+      - summary
+      - keywords
+      - topics
+    slot_usage:
+      summary:
+        required: true
+      topics:
+        range: TopicArea
+        multivalued: true
+        inlined_as_list: true
+
+  TopicArea:
+    description: A research topic-area card that maps a label to a filter tag.
+    class_uri: skos:Concept
+    exact_mappings:
+      - skos:Concept
+    close_mappings:
+      - schema:DefinedTerm
+    slots:
+      - label
+      - tag
+      - description
+      - example_count
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Slots (with SKOS ontology alignment + PROV predicate slot_uris)
+# ─────────────────────────────────────────────────────────────────────────────
+slots:
+
+  name:
+    description: Full display name.
+    slot_uri: schema:name
+    exact_mappings:
+      - schema:name
+      - foaf:name
+    close_mappings:
+      - dcterms:title
+
+  photo:
+    description: Path to the person's photo under public/.
+    slot_uri: schema:image
+    exact_mappings:
+      - schema:image
+    close_mappings:
+      - foaf:depiction
+
+  info:
+    description: Short role / affiliation blurb.
+    slot_uri: schema:description
+    exact_mappings:
+      - schema:description
+    close_mappings:
+      - dcterms:description
+
+  email:
+    description: Contact email address.
+    slot_uri: schema:email
+    exact_mappings:
+      - schema:email
+    close_mappings:
+      - foaf:mbox
+
+  github:
+    description: GitHub username (no URL).
+    exact_mappings:
+      - schema:sameAs
+    related_mappings:
+      - foaf:account
+      - schema:codeRepository
+
+  linkedin:
+    description: LinkedIn profile URL.
+    exact_mappings:
+      - schema:sameAs
+    related_mappings:
+      - foaf:account
+
+  website:
+    description: Personal or lab homepage URL.
+    slot_uri: foaf:homepage
+    exact_mappings:
+      - foaf:homepage
+      - schema:url
+
+  scholar:
+    description: Google Scholar profile URL.
+    exact_mappings:
+      - schema:sameAs
+    related_mappings:
+      - foaf:account
+
+  orcid:
+    description: ORCID iD.
+    exact_mappings:
+      - schema:sameAs
+    related_mappings:
+      - wikidata:P496
+
+  twitter:
+    description: Twitter/X handle.
+    exact_mappings:
+      - schema:sameAs
+    related_mappings:
+      - foaf:account
+
+  bluesky:
+    description: Bluesky handle.
+    exact_mappings:
+      - schema:sameAs
+    related_mappings:
+      - foaf:account
+
+  duration:
+    description: Tenure span in the group, e.g. "2020 - 2025".
+    slot_uri: dcterms:temporal
+    close_mappings:
+      - dcterms:temporal
+      - prov:atTime
+
+  number_educ:
+    description: Count of populated education entries.
+    range: integer
+    related_mappings:
+      - schema:numberOfItems
+
+  education1:
+    description: Education / degree entry.
+    slot_uri: schema:alumniOf
+    exact_mappings:
+      - schema:alumniOf
+    close_mappings:
+      - dcterms:educationLevel
+  education2:
+    description: Education / degree entry.
+    slot_uri: schema:alumniOf
+    exact_mappings:
+      - schema:alumniOf
+  education3:
+    description: Education / degree entry.
+    slot_uri: schema:alumniOf
+    exact_mappings:
+      - schema:alumniOf
+  education4:
+    description: Education / degree entry.
+    slot_uri: schema:alumniOf
+    exact_mappings:
+      - schema:alumniOf
+  education5:
+    description: Education / degree entry.
+    slot_uri: schema:alumniOf
+    exact_mappings:
+      - schema:alumniOf
+
+  current_institution:
+    description: The collaborator's current home institution.
+    slot_uri: schema:affiliation
+    exact_mappings:
+      - schema:affiliation
+    close_mappings:
+      - org:memberOf
+      - prov:atLocation
+
+  projects:
+    description: >-
+      Project slugs / effort names this record is associated with. On a
+      publication this asserts the work was generated by those project
+      activities; on a collaborator, participation in them.
+    multivalued: true
+    slot_uri: prov:wasGeneratedBy
+    related_mappings:
+      - prov:wasGeneratedBy
+      - schema:isPartOf
+
+  years:
+    description: Rough year span of the collaboration.
+    slot_uri: prov:atTime
+    close_mappings:
+      - dcterms:temporal
+
+  note:
+    description: Free-text note.
+    slot_uri: skos:note
+    exact_mappings:
+      - skos:note
+    close_mappings:
+      - rdfs:comment
+
+  slug:
+    description: URL-safe stable identifier.
+    slot_uri: dcterms:identifier
+    exact_mappings:
+      - dcterms:identifier
+    close_mappings:
+      - schema:identifier
+
+  title:
+    description: Title.
+    slot_uri: dcterms:title
+    exact_mappings:
+      - dcterms:title
+      - schema:name
+
+  status:
+    description: Whether the project is active or former.
+    range: ProjectStatus
+    slot_uri: schema:creativeWorkStatus
+    exact_mappings:
+      - schema:creativeWorkStatus
+
+  description:
+    description: One-paragraph description.
+    slot_uri: dcterms:description
+    exact_mappings:
+      - dcterms:description
+      - schema:description
+
+  funder:
+    description: Grant / award identifier(s) with role and co-PIs.
+    slot_uri: schema:funder
+    exact_mappings:
+      - schema:funder
+    close_mappings:
+      - prov:wasAttributedTo
+
+  image:
+    description: Path to a representative image under public/.
+    slot_uri: schema:image
+    exact_mappings:
+      - schema:image
+
+  themes:
+    description: Filterable theme tags for the project.
+    multivalued: true
+    slot_uri: dcterms:subject
+    exact_mappings:
+      - dcterms:subject
+    close_mappings:
+      - schema:keywords
+
+  links:
+    description: Outbound links associated with the project.
+    multivalued: true
+    inlined_as_list: true
+    range: ProjectLink
+    related_mappings:
+      - rdfs:seeAlso
+      - schema:relatedLink
+
+  contributors:
+    description: People associated with the project.
+    range: ProjectContributors
+    inlined: true
+    slot_uri: prov:qualifiedAssociation
+    related_mappings:
+      - schema:contributor
+      - prov:wasAssociatedWith
+
+  publications:
+    description: Cross-reference ids into the publications corpus.
+    multivalued: true
+    slot_uri: prov:generated
+    related_mappings:
+      - prov:generated
+      - schema:workExample
+
+  label:
+    description: Human-readable label.
+    slot_uri: rdfs:label
+    exact_mappings:
+      - rdfs:label
+      - schema:name
+
+  url:
+    description: A URL.
+    slot_uri: schema:url
+    exact_mappings:
+      - schema:url
+    close_mappings:
+      - foaf:page
+
+  display:
+    description: Display text for a link.
+    slot_uri: rdfs:label
+    exact_mappings:
+      - rdfs:label
+
+  current:
+    description: Current lab members contributing to the project.
+    multivalued: true
+    slot_uri: prov:wasAssociatedWith
+    related_mappings:
+      - schema:member
+      - prov:wasAssociatedWith
+
+  former:
+    description: Former lab members who contributed to the project.
+    multivalued: true
+    slot_uri: prov:wasAssociatedWith
+    related_mappings:
+      - schema:alumni
+      - prov:wasAssociatedWith
+
+  external:
+    description: External (non-lab) collaborators, as plain text.
+    multivalued: true
+    related_mappings:
+      - schema:contributor
+      - prov:wasAssociatedWith
+
+  id:
+    description: Stable identifier (DOI, arXiv id, pmid:, or slug).
+    slot_uri: dcterms:identifier
+    exact_mappings:
+      - dcterms:identifier
+      - schema:identifier
+
+  type:
+    description: Publication form.
+    range: PublicationType
+    slot_uri: dcterms:type
+    exact_mappings:
+      - dcterms:type
+    close_mappings:
+      - schema:additionalType
+
+  category:
+    description: Coarse-grained kind of article (orthogonal to form).
+    range: PublicationCategory
+    slot_uri: dcterms:type
+    close_mappings:
+      - schema:genre
+      - fabio:hasPortrayalContext
+
+  year:
+    description: Publication year.
+    range: integer
+    slot_uri: dcterms:date
+    exact_mappings:
+      - fabio:hasPublicationYear
+    close_mappings:
+      - dcterms:date
+      - schema:datePublished
+
+  authors:
+    description: Ordered author display names.
+    multivalued: true
+    slot_uri: prov:wasAttributedTo
+    exact_mappings:
+      - schema:author
+      - dcterms:creator
+    close_mappings:
+      - bibo:authorList
+
+  venue:
+    description: Publication venue (journal, conference, or server).
+    slot_uri: prism:publicationName
+    exact_mappings:
+      - prism:publicationName
+    close_mappings:
+      - dcterms:isPartOf
+      - schema:isPartOf
+
+  doi:
+    description: Digital Object Identifier.
+    slot_uri: prism:doi
+    exact_mappings:
+      - prism:doi
+      - bibo:doi
+    related_mappings:
+      - wikidata:P356
+
+  pmid:
+    description: PubMed identifier.
+    related_mappings:
+      - wikidata:P698
+
+  pmcid:
+    description: PubMed Central identifier.
+    related_mappings:
+      - wikidata:P932
+
+  arxiv:
+    description: arXiv identifier.
+    related_mappings:
+      - wikidata:P818
+
+  pdf_url:
+    description: Direct link to an open-access PDF.
+    slot_uri: schema:url
+    exact_mappings:
+      - schema:url
+    close_mappings:
+      - fabio:hasManifestation
+
+  sources:
+    description: Data sources the record was compiled from.
+    multivalued: true
+    slot_uri: prov:wasDerivedFrom
+    related_mappings:
+      - prov:wasDerivedFrom
+      - dcterms:source
+
+  lab_authors:
+    description: Authors who are (or were) lab members.
+    multivalued: true
+    slot_uri: prov:wasAttributedTo
+    close_mappings:
+      - schema:author
+
+  topics:
+    description: Canonical topic tags for the publication.
+    multivalued: true
+    slot_uri: dcterms:subject
+    exact_mappings:
+      - dcterms:subject
+    close_mappings:
+      - schema:about
+
+  preprints:
+    description: Preprint precursors superseded by this record.
+    multivalued: true
+    inlined_as_list: true
+    range: PreprintRef
+    slot_uri: prov:wasRevisionOf
+    related_mappings:
+      - prov:wasRevisionOf
+      - fabio:hasPreVersion
+
+  cited_by:
+    description: Citation count.
+    range: integer
+    close_mappings:
+      - schema:citation
+    related_mappings:
+      - fabio:hasSubjectTerm
+
+  abstract:
+    description: Verbatim abstract from an authoritative source.
+    slot_uri: dcterms:abstract
+    exact_mappings:
+      - dcterms:abstract
+      - bibo:abstract
+
+  abstract_source:
+    description: Which authoritative source the abstract came from.
+    range: AbstractSource
+    slot_uri: dcterms:source
+    related_mappings:
+      - prov:wasDerivedFrom
+      - dcterms:source
+
+  key_findings:
+    description: Short derived summary of the main contribution.
+    close_mappings:
+      - schema:abstract
+    related_mappings:
+      - dcterms:description
+
+  date:
+    description: Date string.
+    slot_uri: dcterms:date
+    exact_mappings:
+      - dcterms:date
+    close_mappings:
+      - schema:datePublished
+
+  link:
+    description: Primary link with display text.
+    range: LinkDisplay
+    inlined: true
+    slot_uri: schema:url
+    related_mappings:
+      - schema:url
+      - rdfs:seeAlso
+
+  code link:
+    description: Link to associated code with display text.
+    range: LinkDisplay
+    inlined: true
+    related_mappings:
+      - schema:codeRepository
+
+  highlight:
+    description: Highlight rank / flag.
+    range: integer
+    close_mappings:
+      - schema:position
+
+  news1:
+    description: Associated news snippet (HTML).
+    close_mappings:
+      - schema:comment
+      - bibo:Note
+
+  news2:
+    description: Associated news snippet (HTML).
+    close_mappings:
+      - schema:comment
+      - bibo:Note
+
+  headline:
+    description: News headline text.
+    slot_uri: schema:headline
+    exact_mappings:
+      - schema:headline
+    close_mappings:
+      - dcterms:title
+
+  summary:
+    description: Page summary text.
+    slot_uri: dcterms:abstract
+    exact_mappings:
+      - schema:abstract
+    close_mappings:
+      - dcterms:description
+
+  keywords:
+    description: Keyword cloud for the publications page.
+    multivalued: true
+    slot_uri: schema:keywords
+    exact_mappings:
+      - schema:keywords
+      - dcterms:subject
+
+  tag:
+    description: Canonical filter tag for a topic area.
+    slot_uri: skos:notation
+    exact_mappings:
+      - skos:notation
+    close_mappings:
+      - dcterms:subject
+
+  example_count:
+    description: Number of publications carrying this topic tag.
+    range: integer
+    close_mappings:
+      - schema:numberOfItems
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Enums (every permissible value carries a `meaning` ontology binding)
+# ─────────────────────────────────────────────────────────────────────────────
+enums:
+
+  ProjectStatus:
+    description: Lifecycle status of a project.
+    permissible_values:
+      active:
+        description: Ongoing project.
+        meaning: schema:ActiveActionStatus
+      former:
+        description: Completed or paused project.
+        meaning: schema:CompletedActionStatus
+
+  PublicationType:
+    description: The bibliographic form of a publication.
+    permissible_values:
+      journal:
+        description: Peer-reviewed journal article.
+        meaning: fabio:JournalArticle
+      preprint:
+        description: Preprint.
+        meaning: fabio:Preprint
+      conference:
+        description: Conference paper.
+        meaning: fabio:ConferencePaper
+      chapter:
+        description: Book chapter.
+        meaning: fabio:BookChapter
+      workshop:
+        description: Workshop paper.
+        meaning: fabio:ConferencePaper
+      software:
+        description: Software release.
+        meaning: schema:SoftwareSourceCode
+      patent:
+        description: Patent.
+        meaning: fabio:Patent
+      dataset:
+        description: Dataset.
+        meaning: schema:Dataset
+
+  PublicationCategory:
+    description: Coarse-grained kind of article, orthogonal to form.
+    permissible_values:
+      original-research:
+        description: Original research paper.
+        meaning: fabio:ResearchPaper
+      methods:
+        description: Methods paper.
+        meaning: fabio:ResearchPaper
+      software:
+        description: Software paper.
+        meaning: schema:SoftwareSourceCode
+      review:
+        description: Review article.
+        meaning: fabio:ReviewArticle
+      perspective:
+        description: Perspective piece.
+        meaning: fabio:Comment
+      commentary:
+        description: Commentary.
+        meaning: fabio:Comment
+      editorial:
+        description: Editorial.
+        meaning: fabio:Editorial
+      dataset:
+        description: Dataset descriptor.
+        meaning: schema:Dataset
+      benchmark:
+        description: Benchmark study.
+        meaning: fabio:ResearchPaper
+      tutorial:
+        description: Tutorial / educational resource.
+        meaning: schema:LearningResource
+
+  AbstractSource:
+    description: Authoritative source an abstract was pulled from.
+    permissible_values:
+      pubmed:
+        description: PubMed.
+        meaning: wikidata:Q180686
+      pmc:
+        description: PubMed Central.
+        meaning: wikidata:Q229883
+      arxiv:
+        description: arXiv.
+        meaning: wikidata:Q118398
+      openalex:
+        description: OpenAlex.
+        meaning: wikidata:Q107507571
+      crossref:
+        description: Crossref.
+        meaning: wikidata:Q5188229
+      publisher:
+        description: Publisher's website.
+        meaning: schema:Organization

--- a/schema/validate_data.py
+++ b/schema/validate_data.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate the site's YAML data files against the LinkML schema.
+
+Each file in src/data/ is a bare list of records (or, for publications_page,
+a single object). We validate every record against its target class using
+LinkML's programmatic validator and exit non-zero if any ERROR-severity
+result is found.
+
+    python schema/validate_data.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+from linkml.validator import validate
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = ROOT / "schema" / "sensein.yaml"
+DATA = ROOT / "src" / "data"
+
+# file -> (target class, is the file a single object rather than a list?)
+FILES: dict[str, tuple[str, bool]] = {
+    "team_members.yml": ("TeamMember", False),
+    "students.yml": ("TeamMember", False),
+    "alumni_members.yml": ("TeamMember", False),
+    "collaborators.yml": ("Collaborator", False),
+    "projects.yml": ("Project", False),
+    "publications.yml": ("Publication", False),
+    "publist.yml": ("FeaturedPublication", False),
+    "news.yml": ("NewsItem", False),
+    "publications_page.yml": ("PublicationsPage", True),
+}
+
+
+def main() -> int:
+    total_errors = 0
+    total_records = 0
+
+    for fname, (target_class, is_object) in FILES.items():
+        path = DATA / fname
+        if not path.exists():
+            print(f"⚠  {fname}: not found, skipping")
+            continue
+
+        doc = yaml.safe_load(path.read_text())
+        if doc is None:
+            print(f"✓  {fname}: empty ({target_class})")
+            continue
+
+        records = [doc] if is_object else doc
+        if not isinstance(records, list):
+            print(f"✗  {fname}: expected a list of {target_class}, got {type(doc).__name__}")
+            total_errors += 1
+            continue
+
+        file_errors = 0
+        for i, record in enumerate(records):
+            report = validate(record, str(SCHEMA), target_class)
+            for result in report.results:
+                if str(result.severity).upper().endswith("ERROR"):
+                    file_errors += 1
+                    total_errors += 1
+                    label = record.get("id") or record.get("slug") or record.get("name") or f"index {i}"
+                    print(f"✗  {fname}[{label}]: {result.message}")
+        total_records += len(records)
+        mark = "✓" if file_errors == 0 else "✗"
+        print(f"{mark}  {fname}: {len(records)} record(s) validated against {target_class}, {file_errors} error(s)")
+
+    print(f"\n{'─' * 60}")
+    if total_errors:
+        print(f"FAILED: {total_errors} validation error(s) across {total_records} records.")
+        return 1
+    print(f"OK: all {total_records} records conform to the schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/data/alumni_members.yml
+++ b/src/data/alumni_members.yml
@@ -120,7 +120,7 @@
   info: Undergraduate Researcher
   email: vmoroz@mit.edu
   github: "Veronika271"
-  duration: 2025
+  duration: "2025"
   number_educ: 0
 - name: Harsha Gazula
   photo: /images/people/harsha-gazula.webp
@@ -135,7 +135,7 @@
   info: Visiting M.S. student from Technical University of Munich
   email: alina991@mit.edu
   github: "ALINA991"
-  duration: 2024
+  duration: "2024"
   number_educ: 1
   education1: M.S. Neuroengineering, Technichal University of Munich
 - name: Chaitanya Kapoor
@@ -143,7 +143,7 @@
   info: Visiting undergraduate student
   email: ckapoor@mit.edu
   github: "atomic-rooster"
-  duration: 2024
+  duration: "2024"
   number_educ: 1
   education1: B.E. in Electrical and Electronics Engineering, BITS Pilani
 - name: Daniel M. Low
@@ -396,7 +396,7 @@
 - name: Frances Mulligan (They/Them)
   photo: /images/people/frances-mulligan-they-them.webp
   info: Technical Assistant, worked on mumble melody and reproschema
-  duration: 2021
+  duration: "2021"
   number_educ: 1
   education1: B.S, Johnson & Wales University
 - name: Alice Bizeul


### PR DESCRIPTION
## Summary

Adds a **LinkML schema** for every structured data file under `src/data/`, plus a **CI validator** that checks the data against it.

### Schema (`schema/sensein.yaml`)
Covers `team_members` / `students` / `alumni_members` (→ `TeamMember`), `collaborators` (→ `Collaborator`), `projects` (→ `Project` + `ProjectLink` + `ProjectContributors`), `publications` (→ `Publication` + `PreprintRef`), `publist` (→ `FeaturedPublication` + `LinkDisplay`), `news` (→ `NewsItem`), and `publications_page` (→ `PublicationsPage` + `TopicArea`).

**PROV-DM typing** — classes mix in abstract PROV types: people are `prov:Agent`, projects are `prov:Activity`, publications/links/news/page content are `prov:Entity`. Relational slots carry PROV predicates via `slot_uri` (`authors` → `prov:wasAttributedTo`, `preprints` → `prov:wasRevisionOf`, `sources` → `prov:wasDerivedFrom`, `publications`/`projects` → `prov:generated`/`prov:wasGeneratedBy`, `contributors` → `prov:qualifiedAssociation`).

**SKOS ontology alignment** — every class and slot has `exact_mappings` / `close_mappings` / `related_mappings` to schema.org, DCTerms, FOAF, FaBiO/SPAR, BIBO, PRISM, and Wikidata.

**Enum meanings** — every permissible value in `ProjectStatus`, `PublicationType`, `PublicationCategory`, and `AbstractSource` carries a `meaning:` ontology binding (e.g. `journal` → `fabio:JournalArticle`, `pubmed` → `wikidata:Q180686`; the data-source Wikidata QIDs were verified against the Wikidata API).

### Validation
- `schema/validate_data.py` validates every record against its target class via LinkML's programmatic validator and exits non-zero on any error.
- `.github/workflows/validate-data.yml` compiles the schema (`gen-json-schema`) and runs the validator on changes to `src/data/**` or `schema/**`.

### Data fix
The validator caught 4 alumni `duration` values entered as bare integers (single-year visiting/undergrad stints); quoted them to strings as the schema requires.

## Test plan
- [x] `gen-json-schema schema/sensein.yaml` compiles clean
- [x] `python schema/validate_data.py` — **all 400 records across 9 files conform**
- [x] `npm run build` — 205 pages (duration quoting doesn't affect rendering)
- [ ] CI green

https://claude.ai/code/session_01AvCkmLfaM2wk5rxXDc6XRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvCkmLfaM2wk5rxXDc6XRg)_